### PR TITLE
Fix bug where income can't be sorted if value is above max_int

### DIFF
--- a/src/main/java/seedu/address/logic/parser/sort/SortByIncome.java
+++ b/src/main/java/seedu/address/logic/parser/sort/SortByIncome.java
@@ -22,11 +22,24 @@ public class SortByIncome implements Comparator<Person> {
     @Override
     public int compare(Person p1, Person p2) {
 
+        //Since income is Long, have to manually check and return an int
+
         if (this.order.equals("desc")) {
-            return p2.getIncome().convertIncomeToInt() - p1.getIncome().convertIncomeToInt();
+            if (p2.getIncome().convertIncomeToLong() > p1.getIncome().convertIncomeToLong()) {
+                return 1;
+            } else if (p2.getIncome().convertIncomeToLong() < p1.getIncome().convertIncomeToLong()) {
+                return -1;
+            }
+            return 0;
         }
 
-        return p1.getIncome().convertIncomeToInt() - p2.getIncome().convertIncomeToInt();
+        if (p1.getIncome().convertIncomeToLong() > p2.getIncome().convertIncomeToLong()) {
+            return 1;
+        } else if (p1.getIncome().convertIncomeToLong() < p2.getIncome().convertIncomeToLong()) {
+            return -1;
+        }
+
+        return 0;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/IncomeLevel.java
+++ b/src/main/java/seedu/address/model/person/IncomeLevel.java
@@ -41,8 +41,8 @@ public class IncomeLevel {
      * Returns an int from the String of income without the $.
      * @return an int converted from the String.
      */
-    public int convertIncomeToInt() {
-        return Integer.parseInt(this.value.substring(1));
+    public long convertIncomeToLong() {
+        return Long.parseLong(this.value.substring(1));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/SortCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
@@ -39,10 +40,13 @@ public class SortCommandTest {
     public void testCompare() {
         // this is to test the result of compare() in SortByAppointment
         SortByAppointment sortByAppointment = new SortByAppointment("asc");
+        SortByIncome sortByIncome = new SortByIncome("asc");
         int result = sortByAppointment.compare(MUSAB_WITH_NO_APPT, ELLE);
         int result2 = sortByAppointment.compare(MUSAB_WITH_NO_APPT, ALICE);
+        int result3 = sortByIncome.compare(ALICE, AMY);
         assertEquals(1, result);
         assertEquals(0, result2);
+        assertEquals(0, result3);
     }
 
     @Test


### PR DESCRIPTION
Income field can now be sorted even if the income is > MAX_INT, by changing income to Long.