### PR TITLE
Prevent adding consecutive duplicate commands into command history

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -368,6 +368,7 @@ After typing in the command word, the command's parameters and their respective 
 Use the up and down keys to navigate through previously typed commands. Users can edit the command first or press enter to execute the command. 
 * Only valid commands will be saved in the command history
 * Command history will only save up to 20 previously typed valid commands
+* Consecutive duplicate commands will not be saved (e.g entering "list" 3 times in a row will only add "list" to command history once)
 
 ### 5.5 Miscellaneous commands
 

--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -41,7 +41,15 @@ public class CommandHistory implements ReadOnlyCommandHistory {
      * @param commandInput latest valid command entered bu user
      */
     public void addToCommandHistory(String commandInput) {
-        if (commandHistoryList.size() >= MAX_COMMAND_HISTORY_SIZE) {
+        int size = commandHistoryList.size();
+        int latestIndex = size - 1;
+
+        // prevent saving of consecutive duplicate commands
+        if (!commandHistoryList.isEmpty()
+                && commandHistoryList.get(latestIndex).equals(commandInput)) {
+            return;
+        }
+        if (size >= MAX_COMMAND_HISTORY_SIZE) {
             commandHistoryList.remove(0);
         }
         commandHistoryList.add(commandInput);

--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -44,17 +44,17 @@ public class CommandHistory implements ReadOnlyCommandHistory {
         int size = commandHistoryList.size();
         int latestIndex = size - 1;
 
-        resetCurrentIndexToBeyondMaxIndex();
         // prevent saving of consecutive duplicate commands
         if (!commandHistoryList.isEmpty()
                 && commandHistoryList.get(latestIndex).equals(commandInput)) {
+            resetCurrentIndexToBeyondMaxIndex();
             return;
         }
         if (size >= MAX_COMMAND_HISTORY_SIZE) {
             commandHistoryList.remove(0);
         }
         commandHistoryList.add(commandInput);
-
+        resetCurrentIndexToBeyondMaxIndex();
     }
 
     public String getPrevCommand() {

--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -44,6 +44,7 @@ public class CommandHistory implements ReadOnlyCommandHistory {
         int size = commandHistoryList.size();
         int latestIndex = size - 1;
 
+        resetCurrentIndexToBeyondMaxIndex();
         // prevent saving of consecutive duplicate commands
         if (!commandHistoryList.isEmpty()
                 && commandHistoryList.get(latestIndex).equals(commandInput)) {
@@ -53,7 +54,7 @@ public class CommandHistory implements ReadOnlyCommandHistory {
             commandHistoryList.remove(0);
         }
         commandHistoryList.add(commandInput);
-        resetCurrentIndexToBeyondMaxIndex();
+
     }
 
     public String getPrevCommand() {

--- a/src/test/java/seedu/address/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/model/CommandHistoryTest.java
@@ -71,6 +71,7 @@ public class CommandHistoryTest {
     public void addDuplicateValidCommand() {
         CommandHistory expected = new CommandHistory();
         expected.addToCommandHistory("list");
+        expected.setCurrentZeroBasedIndex(1);
 
         CommandHistory actual = new CommandHistory();
         for (int i = 0; i < MAX_COMMAND_HISTORY_SIZE; i++) {

--- a/src/test/java/seedu/address/model/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/model/CommandHistoryTest.java
@@ -68,6 +68,18 @@ public class CommandHistoryTest {
     }
 
     @Test
+    public void addDuplicateValidCommand() {
+        CommandHistory expected = new CommandHistory();
+        expected.addToCommandHistory("list");
+
+        CommandHistory actual = new CommandHistory();
+        for (int i = 0; i < MAX_COMMAND_HISTORY_SIZE; i++) {
+            actual.addToCommandHistory("list");
+        }
+
+        assertEquals(actual, expected);
+    }
+    @Test
     public void getPrevCommand_onEmptyCommandList() {
         CommandHistory actual = new CommandHistory();
         assertEquals("", actual.getPrevCommand());
@@ -170,6 +182,7 @@ public class CommandHistoryTest {
 
         assertEquals(actual.getCurrentZeroBasedIndex(), MAX_COMMAND_HISTORY_SIZE);
     }
+
 
 
     @Test


### PR DESCRIPTION
For example, entering the command "list" 4 times in a row will only add "list" once to the command history.