### PR TITLE
More specific datetime messages

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -4,8 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.logic.parser.ArgumentMultimap.arePrefixesPresent;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_LOCATION;
-import static seedu.address.model.person.DateTime.DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE;
-import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;
 
 import java.time.format.DateTimeParseException;
 

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -58,13 +58,7 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
                 throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
             }
             String str = e.getCause().getMessage();
-            if (str.contains(DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE)) {
-                throw new ParseException(DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
-            }
-            if (str.contains(DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE)) {
-                throw new ParseException(DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE);
-            }
-            throw new ParseException(String.format(Appointment.MESSAGE_CONSTRAINTS));
+            throw new ParseException(str);
         }
 
         return new AddAppointmentCommand(personIndex, appointment);

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -10,7 +10,7 @@ import java.time.format.ResolverStyle;
  * a new LocalDateTime object
  */
 public class DateTimeParser {
-    public static final String DATE_TIME_FORMAT = "d-M-uuuu HH:mm";
+    public static final String DATE_TIME_FORMAT = "dd-MM-uuuu HH:mm";
 
     private static final DateTimeFormatter dateTimeFormatter = java.time.format
             .DateTimeFormatter.ofPattern(DATE_TIME_FORMAT).withResolverStyle(ResolverStyle.STRICT);

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
@@ -3,8 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_LOCATION;
-import static seedu.address.model.person.DateTime.DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE;
-import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;
 
 import java.time.format.DateTimeParseException;
 

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
@@ -50,12 +50,7 @@ public class EditAppointmentCommandParser implements Parser<EditAppointmentComma
                     throw new ParseException(DateTime.MESSAGE_CONSTRAINTS);
                 }
                 String str = e.getCause().getMessage();
-                if (str.contains(DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE)) {
-                    throw new ParseException(DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
-                }
-                if (str.contains(DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE)) {
-                    throw new ParseException(DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE);
-                }
+                throw new ParseException(str);
             }
         }
 

--- a/src/main/java/seedu/address/model/person/DateTime.java
+++ b/src/main/java/seedu/address/model/person/DateTime.java
@@ -14,7 +14,7 @@ public class DateTime implements Comparable<DateTime> {
             "Invalid value for DayOfMonth (valid values 1 - 28/31): ";
     public static final String DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE =
             "Invalid value for MonthOfYear (valid values 1 - 12): ";
-    public static final String MESSAGE_CONSTRAINTS = "Date time must follow format d-M-yyyy HH:mm\n"
+    public static final String MESSAGE_CONSTRAINTS = "Date time must follow format dd-MM-yyyy HH:mm\n"
             + "(e.g \"01-03-2022 18:00\" represents 1-Mar-2022 6:00 PM)";
     private final LocalDateTime localDateTime;
 

--- a/src/main/java/seedu/address/model/person/DateTime.java
+++ b/src/main/java/seedu/address/model/person/DateTime.java
@@ -11,9 +11,9 @@ import java.time.LocalDateTime;
  */
 public class DateTime implements Comparable<DateTime> {
     public static final String DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE =
-            "Invalid value for DayOfMonth (valid values 1 - 28/31)";
+            "Invalid value for DayOfMonth (valid values 1 - 28/31): ";
     public static final String DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE =
-            "Invalid value for MonthOfYear (valid values 1 - 12)";
+            "Invalid value for MonthOfYear (valid values 1 - 12): ";
     public static final String MESSAGE_CONSTRAINTS = "Date time must follow format d-M-yyyy HH:mm\n"
             + "(e.g \"01-03-2022 18:00\" represents 1-Mar-2022 6:00 PM)";
     private final LocalDateTime localDateTime;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -62,7 +62,7 @@ public class CommandTestUtil {
 
     public static final String VALID_DATETIME_23_MAR_2024 = "23-03-2024 01:00";
     public static final String INVALID_DATETIME_210_JAN_2023 = "210-01-2023 01:00";
-    public static final String INVALID_DATETIME_21_13_2023 = "210-13-2023 01:00";
+    public static final String INVALID_DATETIME_21_13_2023 = "21-13-2023 01:00";
 
     public static final String INVALID_DATETIME_NON_INTEGER = "01-Jan-2023 01:00 AM";
     public static final String VALID_LOCATION_NUS = "NUS";
@@ -105,7 +105,7 @@ public class CommandTestUtil {
 
     public static final String INVALID_BOTH_FIELD_APPOINTMENT_DESC = " " + PREFIX_APPOINTMENT_DATE
             + INVALID_DATETIME_210_JAN_2023 + " " + PREFIX_APPOINTMENT_LOCATION + INVALID_LOCATION;
-    public static final String INVALID_OUT_OF_BOUNDS_DAY_APPOINTMENT_DESC = " " + PREFIX_APPOINTMENT_DATE
+    public static final String INVALID_WRONGLENGTH_DAY_APPOINTMENT_DESC = " " + PREFIX_APPOINTMENT_DATE
             + INVALID_DATETIME_210_JAN_2023 + " " + PREFIX_APPOINTMENT_LOCATION + VALID_LOCATION_NUS;
     public static final String INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC = " " + PREFIX_APPOINTMENT_DATE
             + INVALID_DATETIME_21_13_2023 + " " + PREFIX_APPOINTMENT_LOCATION + VALID_LOCATION_NUS;

--- a/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
@@ -8,8 +8,8 @@ import static seedu.address.logic.commands.CommandTestUtil.INCOME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BOTH_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NON_INTEGER_DATE_APPOINTMENT_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_OUT_OF_BOUNDS_DAY_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_WRONGLENGTH_DAY_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.MONTHLY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -20,7 +20,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_22_JAN
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.model.person.DateTime.DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE;
 import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
@@ -72,13 +71,13 @@ public class AddAppointmentCommandParserTest {
                 AddAppointmentCommand.MESSAGE_USAGE);
         int targetPersonIndex = INDEX_SECOND_PERSON.getOneBased();
 
-        // edit appointment with invalid date with out of bounds day of month
+        // edit appointment with invalid date with wrong length day
         assertParseFailure(parser, targetPersonIndex
-                + INVALID_OUT_OF_BOUNDS_DAY_APPOINTMENT_DESC, DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_WRONGLENGTH_DAY_APPOINTMENT_DESC, DateTime.MESSAGE_CONSTRAINTS);
 
         // edit appointment with invalid date with out of bounds month
         assertParseFailure(parser, targetPersonIndex
-                + INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC, DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC, DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE + "13");
 
         // edit appointment with invalid date with non integer values
         assertParseFailure(parser, targetPersonIndex
@@ -91,7 +90,7 @@ public class AddAppointmentCommandParserTest {
 
         // add appointment with invalid location and invalid date
         assertParseFailure(parser, targetPersonIndex
-                + INVALID_BOTH_FIELD_APPOINTMENT_DESC, DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_BOTH_FIELD_APPOINTMENT_DESC, DateTime.MESSAGE_CONSTRAINTS);
 
         // add appointment with no field
         assertParseFailure(parser, targetPersonIndex + "",

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -14,11 +14,11 @@ public class DateTimeParserTest {
 
     public static final String FIRST_VALID_DATE_TIME = "01-04-2023 12:30";
 
-    public static final  String MINUTE_FORMAT = "01-04-2023 12:%s";
-    public static final  String HOUR_FORMAT = "01-04-2023 %s:30";
-    public static final  String DAY_FORMAT = "%s-04-2023 12:30";
-    public static final  String MONTH_FORMAT = "01-%s-2023 12:30";
-    public static final  String YEAR_FORMAT = "01-04-%s 12:30";
+    private static final String MINUTE_FORMAT = "01-04-2023 12:%s";
+    private static final String HOUR_FORMAT = "01-04-2023 %s:30";
+    private static final String DAY_FORMAT = "%s-04-2023 12:30";
+    private static final String MONTH_FORMAT = "01-%s-2023 12:30";
+    private static final String YEAR_FORMAT = "01-04-%s 12:30";
     private static final String OUTOFBOUNDS_MINUTE = "60";
     private static final String OUTOFBOUNDS_HOUR = "24";
     private static final String OUTOFBOUNDS_DAY = "32";
@@ -26,26 +26,50 @@ public class DateTimeParserTest {
 
     private static final String OUTOFBOUNDS_MINUTE_INPUT = String.format(MINUTE_FORMAT, OUTOFBOUNDS_MINUTE);
     private static final String OUTOFBOUNDS_HOUR_INPUT = String.format(HOUR_FORMAT, OUTOFBOUNDS_HOUR);
-    private static final String OUTOFBOUNDS_DAY_INPUT= String.format(DAY_FORMAT, OUTOFBOUNDS_DAY);
+    private static final String OUTOFBOUNDS_DAY_INPUT = String.format(DAY_FORMAT, OUTOFBOUNDS_DAY);
     private static final String OUTOFBOUNDS_MONTH_INPUT = String.format(MONTH_FORMAT, OUTOFBOUNDS_MONTH);
-    public static final String OUTOFBOUNDS_FORMAT = "Text '%s' could not be parsed: Invalid value for %s (valid values %s): %s";
+    private static final String OUTOFBOUNDS_FORMAT =
+            "Text '%s' could not be parsed: Invalid value for %s (valid values %s): %s";
     private static final String WRONGLENGTH_MINUTE_1_INPUT = String.format(MINUTE_FORMAT, "2");
-    private static final String WRONGLENGTH_MINUTE_2_INPUT = String.format(MINUTE_FORMAT, "060");
+    private static final String WRONGLENGTH_MINUTE_2_INPUT = String.format(MINUTE_FORMAT, "002");
     private static final String WRONGLENGTH_HOUR_1_INPUT = String.format(HOUR_FORMAT, "2");
-    private static final String WRONGLENGTH_HOUR_2_INPUT = String.format(HOUR_FORMAT, "020");
-    private static final String WRONGLENGTH_YEAR_1_INPUT = String.format(YEAR_FORMAT, 23);
-    private static final String WRONGLENGTH_YEAR_2_INPUT = String.format(YEAR_FORMAT, 23000);
+    private static final String WRONGLENGTH_HOUR_2_INPUT = String.format(HOUR_FORMAT, "002");
 
-    private static final String OUTOFBOUNDS_MINUTE_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MINUTE_INPUT, "MinuteOfHour", "0 - 59", OUTOFBOUNDS_MINUTE);
-    private static final String OUTOFBOUNDS_HOUR_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_HOUR_INPUT, "HourOfDay", "0 - 23", OUTOFBOUNDS_HOUR);
-    private static final String OUTOFBOUNDS_DAY_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_DAY_INPUT, "DayOfMonth", "1 - 28/31", OUTOFBOUNDS_DAY);
-    private static final String OUTOFBOUNDS_MONTH_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MONTH_INPUT, "MonthOfYear", "1 - 12", OUTOFBOUNDS_MONTH);
-    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_MINUTE_1_INPUT + "' could not be parsed at index 14";
-    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_MINUTE_2_INPUT + "' could not be parsed, unparsed text found at index 16";
-    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_HOUR_1_INPUT + "' could not be parsed at index 11";
-    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_HOUR_2_INPUT +"' could not be parsed at index 13";
-    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_YEAR_1_INPUT + "' could not be parsed at index 6";
-    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_YEAR_2_INPUT + "' could not be parsed at index 6";
+    private static final String WRONGLENGTH_DAY_1_INPUT = String.format(MINUTE_FORMAT, "2");
+    private static final String WRONGLENGTH_DAY_2_INPUT = String.format(MINUTE_FORMAT, "002");
+    private static final String WRONGLENGTH_MONTH_1_INPUT = String.format(HOUR_FORMAT, "1");
+    private static final String WRONGLENGTH_MONTH_2_INPUT = String.format(HOUR_FORMAT, "001");
+    private static final String WRONGLENGTH_YEAR_1_INPUT = String.format(YEAR_FORMAT, 023);
+    private static final String WRONGLENGTH_YEAR_2_INPUT = String.format(YEAR_FORMAT, 00023);
+
+    private static final String OUTOFBOUNDS_MINUTE_ERROR_MESSAGE =
+            String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MINUTE_INPUT, "MinuteOfHour", "0 - 59", OUTOFBOUNDS_MINUTE);
+    private static final String OUTOFBOUNDS_HOUR_ERROR_MESSAGE =
+            String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_HOUR_INPUT, "HourOfDay", "0 - 23", OUTOFBOUNDS_HOUR);
+    private static final String OUTOFBOUNDS_DAY_ERROR_MESSAGE =
+            String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_DAY_INPUT, "DayOfMonth", "1 - 28/31", OUTOFBOUNDS_DAY);
+    private static final String OUTOFBOUNDS_MONTH_ERROR_MESSAGE =
+            String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MONTH_INPUT, "MonthOfYear", "1 - 12", OUTOFBOUNDS_MONTH);
+    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_1 =
+            "Text '" + WRONGLENGTH_MINUTE_1_INPUT + "' could not be parsed at index 14";
+    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_2 =
+            "Text '" + WRONGLENGTH_MINUTE_2_INPUT + "' could not be parsed, unparsed text found at index 16";
+    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_1 =
+            "Text '" + WRONGLENGTH_HOUR_1_INPUT + "' could not be parsed at index 11";
+    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_2 =
+            "Text '" + WRONGLENGTH_HOUR_2_INPUT + "' could not be parsed at index 13";
+    private static final String WRONGLENGTH_DAY_ERROR_MESSAGE_1 =
+            "Text '" + WRONGLENGTH_DAY_1_INPUT + "' could not be parsed at index 14";
+    private static final String WRONGLENGTH_DAY_ERROR_MESSAGE_2 =
+            "Text '" + WRONGLENGTH_DAY_2_INPUT + "' could not be parsed, unparsed text found at index 16";
+    private static final String WRONGLENGTH_MONTH_ERROR_MESSAGE_1 =
+            "Text '" + WRONGLENGTH_MONTH_1_INPUT + "' could not be parsed at index 11";
+    private static final String WRONGLENGTH_MONTH_ERROR_MESSAGE_2 =
+            "Text '" + WRONGLENGTH_MONTH_2_INPUT + "' could not be parsed at index 13";
+    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_1 =
+            "Text '" + WRONGLENGTH_YEAR_1_INPUT + "' could not be parsed at index 6";
+    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_2 =
+            "Text '" + WRONGLENGTH_YEAR_2_INPUT + "' could not be parsed at index 6";
     private DateTimeParser parser = new DateTimeParser();
 
 
@@ -57,7 +81,7 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void parse_outOfBounds_Field_Format_exceptionThrown() {
+    public void parse_outOfBoundsFieldFormat_exceptionThrown() {
         // out of bounds minute
         try {
             LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(OUTOFBOUNDS_MINUTE_INPUT);
@@ -86,7 +110,7 @@ public class DateTimeParserTest {
 
 
     @Test
-    public void parse_wrongNumberOfDigits_Field_Format_exceptionThrown() {
+    public void parse_wrongNumberOfDigitsFieldFormat_exceptionThrown() {
         // wrong number of digits (minute)
         try {
             LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_MINUTE_1_INPUT);
@@ -108,6 +132,28 @@ public class DateTimeParserTest {
             LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_HOUR_2_INPUT);
         } catch (DateTimeException e) {
             assertEquals(WRONGLENGTH_HOUR_ERROR_MESSAGE_2, e.getMessage());
+        }
+        // wrong number of digits (day)
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_DAY_1_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_DAY_ERROR_MESSAGE_1, e.getMessage());
+        }
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_DAY_2_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_DAY_ERROR_MESSAGE_2, e.getMessage());
+        }
+        // wrong number of digits (month)
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_MONTH_1_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_MONTH_ERROR_MESSAGE_1, e.getMessage());
+        }
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_MONTH_2_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_MONTH_ERROR_MESSAGE_2, e.getMessage());
         }
         // wrong number of digits (year)
         try {

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -10,20 +10,42 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 
 
-
 public class DateTimeParserTest {
 
     public static final String FIRST_VALID_DATE_TIME = "01-04-2023 12:30";
-    public static final String SECOND_VALID_DATE_TIME = "02-04-2023 12:30";
-    public static final String THIRD_VALID_DATE_TIME = "03-04-2023 12:30";
-    private static final String INVALID_YEAR = "01-04-23 12:30";
-    private static final String INVALID_MONTH = "01-13-2023 12:30";
-    private static final String INVALID_DAY = "1000-04-2023 12:30";
-    private static final String INVALID_DAY_ERROR_MESSAGE = "Text '1000-04-2023 12:30' could not be parsed: "
-            + "Invalid value for DayOfMonth (valid values 1 - 28/31): 1000";
-    private static final String INVALID_MONTH_ERROR_MESSAGE =
-            "Text '01-13-2023 12:30' could not be parsed: Invalid value for MonthOfYear (valid values 1 - 12): 13";
-    private static final String INVALID_YEAR_ERROR_MESSAGE = "Text '01-04-23 12:30' could not be parsed at index 6";
+
+    public static final  String MINUTE_FORMAT = "01-04-2023 12:%s";
+    public static final  String HOUR_FORMAT = "01-04-2023 %s:30";
+    public static final  String DAY_FORMAT = "%s-04-2023 12:30";
+    public static final  String MONTH_FORMAT = "01-%s-2023 12:30";
+    public static final  String YEAR_FORMAT = "01-04-%s 12:30";
+    private static final String OUTOFBOUNDS_MINUTE = "60";
+    private static final String OUTOFBOUNDS_HOUR = "24";
+    private static final String OUTOFBOUNDS_DAY = "32";
+    private static final String OUTOFBOUNDS_MONTH = "13";
+
+    private static final String OUTOFBOUNDS_MINUTE_INPUT = String.format(MINUTE_FORMAT, OUTOFBOUNDS_MINUTE);
+    private static final String OUTOFBOUNDS_HOUR_INPUT = String.format(HOUR_FORMAT, OUTOFBOUNDS_HOUR);
+    private static final String OUTOFBOUNDS_DAY_INPUT= String.format(DAY_FORMAT, OUTOFBOUNDS_DAY);
+    private static final String OUTOFBOUNDS_MONTH_INPUT = String.format(MONTH_FORMAT, OUTOFBOUNDS_MONTH);
+    public static final String OUTOFBOUNDS_FORMAT = "Text '%s' could not be parsed: Invalid value for %s (valid values %s): %s";
+    private static final String WRONGLENGTH_MINUTE_1_INPUT = String.format(MINUTE_FORMAT, "2");
+    private static final String WRONGLENGTH_MINUTE_2_INPUT = String.format(MINUTE_FORMAT, "060");
+    private static final String WRONGLENGTH_HOUR_1_INPUT = String.format(HOUR_FORMAT, "2");
+    private static final String WRONGLENGTH_HOUR_2_INPUT = String.format(HOUR_FORMAT, "020");
+    private static final String WRONGLENGTH_YEAR_1_INPUT = String.format(YEAR_FORMAT, 23);
+    private static final String WRONGLENGTH_YEAR_2_INPUT = String.format(YEAR_FORMAT, 23000);
+
+    private static final String OUTOFBOUNDS_MINUTE_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MINUTE_INPUT, "MinuteOfHour", "0 - 59", OUTOFBOUNDS_MINUTE);
+    private static final String OUTOFBOUNDS_HOUR_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_HOUR_INPUT, "HourOfDay", "0 - 23", OUTOFBOUNDS_HOUR);
+    private static final String OUTOFBOUNDS_DAY_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_DAY_INPUT, "DayOfMonth", "1 - 28/31", OUTOFBOUNDS_DAY);
+    private static final String OUTOFBOUNDS_MONTH_ERROR_MESSAGE = String.format(OUTOFBOUNDS_FORMAT, OUTOFBOUNDS_MONTH_INPUT, "MonthOfYear", "1 - 12", OUTOFBOUNDS_MONTH);
+    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_MINUTE_1_INPUT + "' could not be parsed at index 14";
+    private static final String WRONGLENGTH_MINUTE_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_MINUTE_2_INPUT + "' could not be parsed, unparsed text found at index 16";
+    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_HOUR_1_INPUT + "' could not be parsed at index 11";
+    private static final String WRONGLENGTH_HOUR_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_HOUR_2_INPUT +"' could not be parsed at index 13";
+    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_1 = "Text '" + WRONGLENGTH_YEAR_1_INPUT + "' could not be parsed at index 6";
+    private static final String WRONGLENGTH_YEAR_ERROR_MESSAGE_2 = "Text '" + WRONGLENGTH_YEAR_2_INPUT + "' could not be parsed at index 6";
     private DateTimeParser parser = new DateTimeParser();
 
 
@@ -35,32 +57,70 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void parse_dateTimeInvalidDayOfMonthFormat_exceptionThrown() {
+    public void parse_outOfBounds_Field_Format_exceptionThrown() {
+        // out of bounds minute
         try {
-            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(INVALID_DAY);
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(OUTOFBOUNDS_MINUTE_INPUT);
         } catch (DateTimeException e) {
-            assertEquals(INVALID_DAY_ERROR_MESSAGE, e.getMessage());
+            assertEquals(OUTOFBOUNDS_MINUTE_ERROR_MESSAGE, e.getMessage());
+        }
+        // out of bounds hour
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(OUTOFBOUNDS_HOUR_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(OUTOFBOUNDS_HOUR_ERROR_MESSAGE, e.getMessage());
+        }
+        // out of bounds day
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(OUTOFBOUNDS_DAY_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(OUTOFBOUNDS_DAY_ERROR_MESSAGE, e.getMessage());
+        }
+        // out of bounds month
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(OUTOFBOUNDS_MONTH_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(OUTOFBOUNDS_MONTH_ERROR_MESSAGE, e.getMessage());
         }
     }
+
 
     @Test
-    public void parse_dateTimeInvalidMonthFormat_exceptionThrown() {
+    public void parse_wrongNumberOfDigits_Field_Format_exceptionThrown() {
+        // wrong number of digits (minute)
         try {
-            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(INVALID_MONTH);
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_MINUTE_1_INPUT);
         } catch (DateTimeException e) {
-            assertEquals(INVALID_MONTH_ERROR_MESSAGE, e.getMessage());
+            assertEquals(WRONGLENGTH_MINUTE_ERROR_MESSAGE_1, e.getMessage());
+        }
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_MINUTE_2_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_MINUTE_ERROR_MESSAGE_2, e.getMessage());
+        }
+        // wrong number of digits (hour)
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_HOUR_1_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_HOUR_ERROR_MESSAGE_1, e.getMessage());
+        }
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_HOUR_2_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_HOUR_ERROR_MESSAGE_2, e.getMessage());
+        }
+        // wrong number of digits (year)
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_YEAR_1_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_YEAR_ERROR_MESSAGE_1, e.getMessage());
+        }
+        try {
+            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(WRONGLENGTH_YEAR_2_INPUT);
+        } catch (DateTimeException e) {
+            assertEquals(WRONGLENGTH_YEAR_ERROR_MESSAGE_2, e.getMessage());
         }
     }
-
-    @Test
-    public void parse_dateTimeInvalidYearFormat_exceptionThrown() {
-        try {
-            LocalDateTime parsedLocalDateTime = parser.parseLocalDateTimeFromString(INVALID_YEAR);
-        } catch (DateTimeException e) {
-            assertEquals(INVALID_YEAR_ERROR_MESSAGE, e.getMessage());
-        }
-    }
-
     @Test
     public void isValidDateTime_success() {
         assertTrue(DateTimeParser.isValidDateTime(FIRST_VALID_DATE_TIME));
@@ -69,6 +129,6 @@ public class DateTimeParserTest {
 
     @Test
     public void isValidDateTime_failure() {
-        assertFalse(DateTimeParser.isValidDateTime(INVALID_DAY));
+        assertFalse(DateTimeParser.isValidDateTime(OUTOFBOUNDS_DAY));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
@@ -6,8 +6,8 @@ import static seedu.address.logic.commands.CommandTestUtil.FIRST_APPOINTMENT_DES
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BOTH_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NON_INTEGER_DATE_APPOINTMENT_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_OUT_OF_BOUNDS_DAY_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_WRONGLENGTH_DAY_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_21_JAN_2023;
@@ -16,7 +16,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.model.person.DateTime.DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE;
 import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_APPOINTMENT;
@@ -93,13 +92,13 @@ public class EditAppointmentCommandParserTest {
         int targetIndex = INDEX_SECOND_PERSON.getOneBased();
         int targetAppointmentIndex = INDEX_SECOND_APPOINTMENT.getOneBased();
 
-        // edit appointment with invalid date with out of bounds day of month
+        // edit appointment with invalid date with wrong length day
         assertParseFailure(parser, targetIndex + "." + targetAppointmentIndex
-                + INVALID_OUT_OF_BOUNDS_DAY_APPOINTMENT_DESC, DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_WRONGLENGTH_DAY_APPOINTMENT_DESC, DateTime.MESSAGE_CONSTRAINTS);
 
         // edit appointment with invalid date with out of bounds month
         assertParseFailure(parser, targetIndex + "." + targetAppointmentIndex
-                + INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC, DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_OUT_OF_BOUNDS_MONTH_APPOINTMENT_DESC, DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE + "13");
 
         // edit appointment with invalid date with non integer values
         assertParseFailure(parser, targetIndex + "." + targetAppointmentIndex
@@ -111,7 +110,7 @@ public class EditAppointmentCommandParserTest {
 
         // edit appointment with invalid date(out of bounds day) and location
         assertParseFailure(parser, targetIndex + "." + targetAppointmentIndex
-                + INVALID_BOTH_FIELD_APPOINTMENT_DESC, DEFAULT_DAY_OUT_OF_BOUNDS_ERROR_MESSAGE);
+                + INVALID_BOTH_FIELD_APPOINTMENT_DESC, DateTime.MESSAGE_CONSTRAINTS);
 
         // edit appointment with no field
         assertParseFailure(parser, targetIndex + "." + targetAppointmentIndex

--- a/src/test/java/seedu/address/model/calendar/CalendarMonthTest.java
+++ b/src/test/java/seedu/address/model/calendar/CalendarMonthTest.java
@@ -21,13 +21,13 @@ public class CalendarMonthTest {
     private static final Name AMY = new Name("Amy");
     private static final Name BOB = new Name("Bob");
     private static final Appointment firstAppointment = new Appointment(new DateTime(
-            DateTimeParser.parseLocalDateTimeFromString("1-4-2023 01:00")),
+            DateTimeParser.parseLocalDateTimeFromString("01-04-2023 01:00")),
             new Location("NUS TechnoEdge"));
     private static final Appointment secondAppointment = new Appointment(new DateTime(
-            DateTimeParser.parseLocalDateTimeFromString("1-5-2023 01:00")),
+            DateTimeParser.parseLocalDateTimeFromString("01-05-2023 01:00")),
             new Location("NUS TechnoEdge"));
     private static final Appointment thirdAppointment = new Appointment(new DateTime(
-            DateTimeParser.parseLocalDateTimeFromString("1-4-2024 01:00")),
+            DateTimeParser.parseLocalDateTimeFromString("01-04-2024 01:00")),
             new Location("NUS TechnoEdge"));
 
 

--- a/src/test/java/seedu/address/model/person/AppointmentTest.java
+++ b/src/test/java/seedu/address/model/person/AppointmentTest.java
@@ -58,12 +58,12 @@ public class AppointmentTest {
      */
     private static class DateTimeStub extends DateTime {
         DateTimeStub() {
-            super(DateTimeParser.parseLocalDateTimeFromString("1-04-2023 12:30"));
+            super(DateTimeParser.parseLocalDateTimeFromString("01-04-2023 12:30"));
         }
 
         @Override
         public String toString() {
-            return "1-04-2023 12:30";
+            return "01-04-2023 12:30";
         }
     }
 
@@ -99,7 +99,7 @@ public class AppointmentTest {
     @Test
     public void versionToString_validVersion_correctStringRepresentation() {
         Appointment newAppointment = new Appointment(new DateTimeStub(), new ValidLocationStub());
-        Assertions.assertEquals("1-04-2023 12:30, NUS TechnoEdge", newAppointment.toString());
+        Assertions.assertEquals("01-04-2023 12:30, NUS TechnoEdge", newAppointment.toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -61,7 +61,7 @@ public class UniquePersonListTest {
     @Test
     public void containsPersonWithSameDateTimeAppointment_personNotInList_returnsFalse() {
         Appointment uniqueAppointment = new AppointmentBuilder()
-                .withDateTime("1-1-1880 12:00")
+                .withDateTime("01-01-1880 12:00")
                 .withLocation(VALID_LOCATION_NUS).build();
         assertFalse(uniquePersonList.containsPersonWithSameAppointmentDateTime(uniqueAppointment));
     }

--- a/src/test/java/seedu/address/testutil/CalendarMonthBuilder.java
+++ b/src/test/java/seedu/address/testutil/CalendarMonthBuilder.java
@@ -18,9 +18,9 @@ public class CalendarMonthBuilder {
 
     private static final String DEFAULT_FIRST_NAME = "Amy";
     private static final String DEFAULT_SECOND_NAME = "Bob";
-    private static final String DEFAULT_FIRST_DATE = "1-04-2023 01:00";
-    private static final String DEFAULT_SECOND_DATE = "1-5-2023 01:00";
-    private static final String DEFAULT_THIRD_DATE = "1-4-2024 01:00";
+    private static final String DEFAULT_FIRST_DATE = "01-04-2023 01:00";
+    private static final String DEFAULT_SECOND_DATE = "01-05-2023 01:00";
+    private static final String DEFAULT_THIRD_DATE = "01-04-2024 01:00";
     private ObservableList<CalendarEvent> eventList;
 
     /**


### PR DESCRIPTION
I changed the date time input to accept all numbers only.

*Current format:*
`dd-MM-yyyy HH:mm `
- day, month, hour, minutes are strictly 2 digits,
- year is strictly 4 digits)

*New valid date inputs:*
`04-02-2023 12:30`
`         04-02-2023       12:30             `
`04-02-0023 02:30`
`04-02-2023 12:30`
<br><br>



*Wrong format/Non-integer/Wrong number of digits for day ,month ,year, hour, minutes:*

        Date time must follow format dd-MM-yyyy HH:mm 
          (e.g "01-03-2022 18:00" represents 1-Mar-2022 6:00 PM)
          
          
*Out of bounds day error message:*

        Invalid value for DayOfMonth (valid values 1 - 28/31): 69

          
*Out of bounds month error message:*

        Invalid value for MonthOfYear (valid values 1 - 12): 13

*Out of bounds hour error message:*

        Invalid value for HourOfDay (valid values 0 - 23): 24

*Out of bounds minute error message:*

        Invalid value for MinuteOfHour (valid values 0 - 59): 60

*Within bounds but invalid error message:*

        Invalid date `FEBRUARY 31`
        
*Within bounds but invalid error message(leap year):*

        Invalid date 'February 29' as '2017' is not a leap year
        