### PR TITLE
Show invalid index for Edit and Delete Command when index <= 0

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,9 +7,9 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index number provided is invalid";
     public static final String MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX =
-            "The appointment index provided is invalid";
+            "The appointment index number provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,21 @@ public class StringUtil {
             return false;
         }
     }
+    /**
+     * Returns true if {@code s} represents a non-zero unsigned integer
+     * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            return !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -21,9 +21,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
 
         // Throw invalid index error only if index is an integer and is lower than or equals to 0
-        if (isInteger(args)
-        && Integer.parseInt(args) <= 0) {
-           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (isInteger(args) && Integer.parseInt(args) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         // Throw invalid format error only if index is not an integer

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -17,6 +19,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+
+        // Throw invalid index error only if index is an integer and is lower than or equals to 0
+        if (isInteger(args)
+        && Integer.parseInt(args) <= 0) {
+           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        // Throw invalid format error only if index is not an integer
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -46,9 +46,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         String oneBasedIndexStr = argMultimap.getPreamble();
 
         // Throw invalid index error only if index is an integer and is lower than or equals to 0
-        if (isInteger(oneBasedIndexStr)
-        && Integer.parseInt(oneBasedIndexStr) <= 0) {
-           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (isInteger(oneBasedIndexStr) && Integer.parseInt(oneBasedIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         // Throw invalid format error only if index is not an integer

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CLIENTTAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -41,9 +43,17 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_RISKTAG, PREFIX_PLANTAG, PREFIX_CLIENTTAG, PREFIX_TAG);
 
         Index index;
+        String oneBasedIndexStr = argMultimap.getPreamble();
 
+        // Throw invalid index error only if index is an integer and is lower than or equals to 0
+        if (isInteger(oneBasedIndexStr)
+        && Integer.parseInt(oneBasedIndexStr) <= 0) {
+           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        // Throw invalid format error only if index is not an integer
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(oneBasedIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -28,5 +29,6 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1", MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.CLIENTTAG_DESC_CURRENT;
@@ -86,10 +87,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
*Wrong format/index is not an integer*

    Invalid command format! 
    edit: Edits the details of the person identified by the index number used in the displayed person list. Existing values will be 
    overwritten by the input values.
    Parameters: INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [i/YEARLY_INCOME] [m/MONTHLY_CONTRIBUTION] 
    [r/RISK_APPETITE] [ip/INVESTMENT_PLAN] [c/CLIENT_TYPE] [t/TAG]...

*Example invalid command format inputs:*
`edit 1 z/hello n/validName` (invalid index "1 z/hello")
`edit 1a n/validName` (invalid index "1a")
`delete abc` (invalid index "abc")
`delete 1 n/validName` (invalid index "1 n/validName")
 <br><br><br><br><br><br>


*Index is an integer but incorrect value*

        The person index number provided is invalid


*Example invalid index value inputs:*
`edit 0 n/validName` (invalid index "0")
`edit -1 n/validName ` (invalid index "-1") 
`edit 100 n/validName ` (invalid index "100" if out of bounds for client list) 
`delete 0` (invalid index "0")
`delete -1` (invalid index "-1") 
`delete 100` (invalid index "100" if out of bounds for client list) 
Resolves #226 