### PR TITLE
Show invalid index for Appointment Commands when index <= 0

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,9 +7,9 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index number provided is invalid";
     public static final String MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX =
-            "The appointment index provided is invalid";
+            "The appointment index number provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -65,4 +65,21 @@ public class StringUtil {
             return false;
         }
     }
+    /**
+     * Returns true if {@code s} represents a non-zero unsigned integer
+     * e.g. 1, 2, 3, ..., {@code Integer.MAX_VALUE} <br>
+     * Will return false for any other non-null string input
+     * e.g. empty string, "-1", "0", "+1", and " 2 " (untrimmed), "3 0" (contains whitespace), "1 a" (contains letters)
+     * @throws NullPointerException if {@code s} is null.
+     */
+    public static boolean isInteger(String s) {
+        requireNonNull(s);
+
+        try {
+            int value = Integer.parseInt(s);
+            return !s.startsWith("+"); // "+1" is successfully parsed by Integer#parseInt(String)
+        } catch (NumberFormatException nfe) {
+            return false;
+        }
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 import static seedu.address.logic.parser.ArgumentMultimap.arePrefixesPresent;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_LOCATION;
@@ -35,9 +37,13 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         }
 
         Index personIndex;
+        String oneBasedPersonIndexStr = argMultimap.getPreamble();
+        if (isInteger(oneBasedPersonIndexStr) && Integer.parseInt(oneBasedPersonIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
 
         try {
-            personIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+            personIndex = ParserUtil.parseIndex(oneBasedPersonIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddAppointmentCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteAppointmentCommandParser.java
@@ -1,7 +1,10 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteAppointmentCommand;
@@ -23,10 +26,25 @@ public class DeleteAppointmentCommandParser implements Parser<DeleteAppointmentC
         Index personIndex;
         Index appointmentIndex;
 
+        String personAppointmentIndex = argMultimap.getPreamble().trim();
+        String[] splitStr = personAppointmentIndex.split("\\.");
+        if (splitStr.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    DeleteAppointmentCommand.MESSAGE_USAGE));
+        }
+
+        String oneBasedPersonIndexStr = splitStr[0];
+        if (isInteger(oneBasedPersonIndexStr) && Integer.parseInt(oneBasedPersonIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        String oneBasedAppointmentIndexStr = splitStr[1];
+        if (isInteger(oneBasedAppointmentIndexStr) && Integer.parseInt(oneBasedAppointmentIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
+        }
         try {
-            String personAppointmentIndex = argMultimap.getPreamble();
-            personIndex = ParserUtil.parsePersonIndex(personAppointmentIndex);
-            appointmentIndex = ParserUtil.parseAppointmentIndex(personAppointmentIndex);
+            personIndex = ParserUtil.parseIndex(oneBasedPersonIndexStr);
+            appointmentIndex = ParserUtil.parseIndex(oneBasedAppointmentIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     DeleteAppointmentCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -21,9 +21,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
     public DeleteCommand parse(String args) throws ParseException {
 
         // Throw invalid index error only if index is an integer and is lower than or equals to 0
-        if (isInteger(args)
-        && Integer.parseInt(args) <= 0) {
-           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (isInteger(args) && Integer.parseInt(args) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         // Throw invalid format error only if index is not an integer

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
@@ -17,6 +19,14 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
+
+        // Throw invalid index error only if index is an integer and is lower than or equals to 0
+        if (isInteger(args)
+        && Integer.parseInt(args) <= 0) {
+           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        // Throw invalid format error only if index is not an integer
         try {
             Index index = ParserUtil.parseIndex(args);
             return new DeleteCommand(index);

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
@@ -34,7 +34,7 @@ public class EditAppointmentCommandParser implements Parser<EditAppointmentComma
         String personAppointmentIndex = argMultimap.getPreamble().trim();
         String[] splitStr = personAppointmentIndex.split("\\.");
         if (splitStr.length != 2) {
-             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditAppointmentCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditAppointmentCommandParser.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_LOCATION;
 
@@ -28,10 +31,26 @@ public class EditAppointmentCommandParser implements Parser<EditAppointmentComma
         Index personIndex;
         Index appointmentIndex;
 
+        String personAppointmentIndex = argMultimap.getPreamble().trim();
+        String[] splitStr = personAppointmentIndex.split("\\.");
+        if (splitStr.length != 2) {
+             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditAppointmentCommand.MESSAGE_USAGE));
+        }
+
+        String oneBasedPersonIndexStr = splitStr[0];
+        if (isInteger(oneBasedPersonIndexStr) && Integer.parseInt(oneBasedPersonIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        String oneBasedAppointmentIndexStr = splitStr[1];
+        if (isInteger(oneBasedAppointmentIndexStr) && Integer.parseInt(oneBasedAppointmentIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
+        }
+
         try {
-            String personAppointmentIndex = argMultimap.getPreamble();
-            personIndex = ParserUtil.parsePersonIndex(personAppointmentIndex);
-            appointmentIndex = ParserUtil.parseAppointmentIndex(personAppointmentIndex);
+            personIndex = ParserUtil.parseIndex(oneBasedPersonIndexStr);
+            appointmentIndex = ParserUtil.parseIndex(oneBasedAppointmentIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     EditAppointmentCommand.MESSAGE_USAGE), pe);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -46,9 +46,8 @@ public class EditCommandParser implements Parser<EditCommand> {
         String oneBasedIndexStr = argMultimap.getPreamble();
 
         // Throw invalid index error only if index is an integer and is lower than or equals to 0
-        if (isInteger(oneBasedIndexStr)
-        && Integer.parseInt(oneBasedIndexStr) <= 0) {
-           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (isInteger(oneBasedIndexStr) && Integer.parseInt(oneBasedIndexStr) <= 0) {
+            throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
         // Throw invalid format error only if index is not an integer

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,8 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.util.StringUtil.isInteger;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CLIENTTAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -41,9 +43,17 @@ public class EditCommandParser implements Parser<EditCommand> {
                 PREFIX_RISKTAG, PREFIX_PLANTAG, PREFIX_CLIENTTAG, PREFIX_TAG);
 
         Index index;
+        String oneBasedIndexStr = argMultimap.getPreamble();
 
+        // Throw invalid index error only if index is an integer and is lower than or equals to 0
+        if (isInteger(oneBasedIndexStr)
+        && Integer.parseInt(oneBasedIndexStr) <= 0) {
+           throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        // Throw invalid format error only if index is not an integer
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(oneBasedIndexStr);
         } catch (ParseException pe) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -52,38 +52,6 @@ public class ParserUtil {
     }
 
     /**
-     * Parses {@code personAppointmentIndex} into an {@code Index} and returns the appointment index.
-     * Leading and trailing whitespaces will be trimmed.
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
-     */
-    public static Index parseAppointmentIndex(String personAppointmentIndex) throws ParseException {
-        requireNonNull(personAppointmentIndex);
-        String trimmedAppointmentIndex = personAppointmentIndex.trim();
-        String[] splitStr = trimmedAppointmentIndex.split("\\.");
-
-        if (splitStr.length != 2 || !StringUtil.isNonZeroUnsignedInteger(splitStr[1])) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
-        }
-        return Index.fromOneBased(Integer.parseInt(splitStr[1]));
-    }
-
-    /**
-     * Parses {@code personAppointmentIndex} into an {@code Index} and returns the person index.
-     * Leading and trailing whitespaces will be trimmed.
-     * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
-     */
-    public static Index parsePersonIndex(String personAppointmentIndex) throws ParseException {
-        requireNonNull(personAppointmentIndex);
-        String trimmedAppointmentIndex = personAppointmentIndex.trim();
-        String[] splitStr = trimmedAppointmentIndex.split("\\.");
-
-        if (splitStr.length != 2 || !StringUtil.isNonZeroUnsignedInteger(splitStr[0])) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
-        }
-        return Index.fromOneBased(Integer.parseInt(splitStr[0]));
-    }
-
-    /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.
      *

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.EditAppointmentCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SortCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -130,6 +131,9 @@ public class CommandBox extends UiPart<Region> {
                 break;
             case ExitCommand.COMMAND_WORD:
                 resultDisplay.setFeedbackToUser(ExitCommand.MESSAGE_USAGE);
+                break;
+            case HelpCommand.COMMAND_WORD:
+                resultDisplay.setFeedbackToUser(HelpCommand.MESSAGE_USAGE);
                 break;
             default:
                 break;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -115,6 +115,7 @@ public class CommandTestUtil {
             + VALID_DATETIME_21_JAN_2023 + " " + PREFIX_APPOINTMENT_LOCATION + INVALID_LOCATION;
     public static final String VALID_LOCATION_FIELD_APPOINTMENT_DESC = " "
             + PREFIX_APPOINTMENT_LOCATION + VALID_LOCATION_NUS;
+
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
@@ -17,8 +17,6 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.RISKTAG_DESC_HIGH;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_21_JAN_2023;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_22_JAN_2023;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;

--- a/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAppointmentCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.FIRST_APPOINTMENT_DESC;
@@ -17,6 +18,7 @@ import static seedu.address.logic.commands.CommandTestUtil.RISKTAG_DESC_HIGH;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_21_JAN_2023;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_22_JAN_2023;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -54,16 +56,16 @@ public class AddAppointmentCommandParserTest {
         String expectedFailureMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddAppointmentCommand.MESSAGE_USAGE);
         // negative index
-        assertParseFailure(parser, "-5" + VALID_DATETIME_21_JAN_2023, expectedFailureMessage);
+        assertParseFailure(parser, "-5" + FIRST_APPOINTMENT_DESC, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + VALID_DATETIME_22_JAN_2023, expectedFailureMessage);
+        assertParseFailure(parser, "0" + FIRST_APPOINTMENT_DESC, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", expectedFailureMessage);
+        assertParseFailure(parser, "1 some random string" + FIRST_APPOINTMENT_DESC, expectedFailureMessage);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", expectedFailureMessage);
+        assertParseFailure(parser, "1 i/ string" + FIRST_APPOINTMENT_DESC, expectedFailureMessage);
     }
     @Test
     public void parse_invalidAppointmentField_failure() {

--- a/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteAppointmentCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
@@ -33,5 +35,7 @@ public class DeleteAppointmentCommandParserTest {
                 DeleteAppointmentCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "1.1.1", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteAppointmentCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "1.-1", MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
+        assertParseFailure(parser, "-1.1", MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -28,5 +29,6 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "-1", MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
@@ -13,11 +13,9 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_WRONGLENGTH_D
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_21_JAN_2023;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_22_JAN_2023;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;

--- a/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditAppointmentCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.FIRST_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_BOTH_FIELD_APPOINTMENT_DESC;
@@ -12,8 +14,10 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_21_JAN_2023;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DATETIME_22_JAN_2023;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_FIELD_APPOINTMENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOCATION_NUS;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.model.person.DateTime.DEFAULT_MONTH_OUT_OF_BOUNDS_ERROR_MESSAGE;
@@ -49,25 +53,30 @@ public class EditAppointmentCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative person index
-        assertParseFailure(parser, "-5.5" + VALID_DATETIME_21_JAN_2023, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5.5" + VALID_LOCATION_FIELD_APPOINTMENT_DESC,
+                MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // negative appointment index
-        assertParseFailure(parser, "5.-5" + VALID_DATETIME_21_JAN_2023, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "5.-5" + VALID_LOCATION_FIELD_APPOINTMENT_DESC,
+                MESSAGE_INVALID_APPOINTMENT_DISPLAYED_INDEX);
 
         // only one index
-        assertParseFailure(parser, "1" + VALID_DATETIME_21_JAN_2023, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1" + VALID_LOCATION_FIELD_APPOINTMENT_DESC, MESSAGE_INVALID_FORMAT);
 
         // zero index
-        assertParseFailure(parser, "0" + VALID_DATETIME_22_JAN_2023, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + VALID_LOCATION_FIELD_APPOINTMENT_DESC, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble for person index
-        assertParseFailure(parser, "1 some random string.1", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string.1" + VALID_LOCATION_FIELD_APPOINTMENT_DESC,
+                MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble for appointment index
-        assertParseFailure(parser, "1.1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1.1 some random string" + VALID_LOCATION_FIELD_APPOINTMENT_DESC,
+                MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string" + VALID_LOCATION_FIELD_APPOINTMENT_DESC,
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.CLIENTTAG_DESC_CURRENT;
@@ -86,10 +87,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
*Wrong format/PersonAppointmentIndex is not 2 integers separated by a "."/ PersonIndex is not an integer*

    Invalid command format! 
    ea: Edits a person's appointment using the index numbers from the displayed person list and the identified person's 
    appointment list.
    Parameters: PERSON_INDEX.APPOINTMENT_INDEX [d/DATE] [l/LOCATION]
    Example: ea 3.1 d/09-01-2023 12:30 l/Jurong Point, Starbucks

*Example invalid command format inputs:*
`aa 1.1 l/validLocationName d/validDateTime` (invalid PersonIndex "1.1")
`ea 1 z/hello l/validLocation` (invalid PersonAppoinmentIndex "1 z/hello")
`ea a.1 l/validLocation` (invalid PersonAppoinmentIndex "a.1")
`ea 1.a l/validLocation` (invalid PersonAppoinmentIndex "1.a")
`da a.1` (invalid PersonAppoinmentIndex "1a.1")
 <br><br>

*Person Index is an integer but incorrect value*

        The person index number provided is invalid


*Example invalid PersonIndex value inputs:*
`aa 0 l/validLocation d/validDateTime` (invalid PersonIndex "0")
`ea 0.1 l/validLocation` (invalid PersonIndex "0")
`ea 100.1 l/validLocation` (invalid PersonIndex "100" if out of bounds for client list)
`da -1.1` (invalid PersonIndex "-1")
<br><br>


*Appointment Index is an integer but incorrect value*

        The appointment index number provided is invalid


*Example invalid AppointmentIndex value inputs:*
`ea 1.0 l/validLocation` (invalid AppointmentIndex "0")
`ea 1.100 l/validLocation` (invalid AppointmentIndex "100" if out of bounds for client list)
`da 1.-1` (invalid AppointmentIndex "-1")
